### PR TITLE
Fixup jshint in Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,24 +69,19 @@ module.exports = function(grunt) {
     },
     jshint: {
       options: {
-        reporter: optionalDependencies ? require('jshint-stylish') : undefined
+        jshintrc: '.jshintrc',
+        reporter: optionalDependencies ? require('jshint-stylish') : undefined,
+        reporterOutput: ""
       },
       package: {
-        options: {
-          jshintrc: '.jshintrc'
-        },
-        src: 'package.json'
+        files: {
+          src: 'package.json'
+        }
       },
       gruntfile: {
-        options: {
-          jshintrc: '.jshintrc'
-        },
         src: 'Gruntfile.js'
       },
       js: {
-        options: {
-          jshintrc: '.jshintrc'
-        },
         src: 'src/js/**/*.js'
       }
     },


### PR DESCRIPTION
Was throwing "Warning: Path must be a string. Received null Use --force
to continue." See https://github.com/jshint/jshint/issues/2922

Also move shared jshintrc into root options.
